### PR TITLE
introducing command handler: self in a function version of command handler

### DIFF
--- a/_posts/2017-09-07-introducing-command-handler.md
+++ b/_posts/2017-09-07-introducing-command-handler.md
@@ -235,7 +235,7 @@ def ReportIssue(issue_log, cmd):
         cmd.reporter_name,
         cmd.reporter_email)
     issue = Issue(reported_by, cmd.problem_description)
-    self.issue_log.add(issue)
+    issue_log.add(issue)
 
 
 If magic methods make you feel queasy, you can define a handler to be a class


### PR DESCRIPTION
Seems like `self` got mistakenly copied over from the previous method.

P.S.: I'm a bit confused with the class-based command handler description:
> Command handlers are stateless objects that orchestrate the behaviour of a system.

But we do have a state stored in the handler (as issue log):
```py
def __init__(self, issue_log):
        self.issue_log = issue_log
```

And then we modify it in `__call__`:
```py
...
self.issue_log.add(issue)
```

Just curious if this is also a mistake or issue log is not considered a state?